### PR TITLE
Updated service file to solve error

### DIFF
--- a/installing.md
+++ b/installing.md
@@ -69,9 +69,9 @@ After=network.target
 
 [Service]
 User=<user to run the service>
-Group=<(optional) goup with permissions to access augur_view directory>
+Group=<(optional) group with permissions to access augur_view directory>
 WorkingDirectory=<augur_view directory absolute path>
-ExecStart=env/bin/gunicorn -c gunicorn.conf -b 0.0.0.0:8000 wsgi:app
+ExecStart=<augur_view directory absolute path>/env/bin/gunicorn -c gunicorn.conf -b 0.0.0.0:8000 wsgi:app
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Signed-off-by: Priya <shivikapriya730@gmail.com>
Current Behaviour: On starting the service file the following error occurs:
`Failed to start augur_view.service: Unit augur_view.service has a bad unit file setting.` and the log shows: `

`Neither a valid executable name nor an absolute path `
`Unit configuration has fatal error, unit will not be started.`

Solution and changes made:
- Updating the service file adding absolute path of directory to ExecStart.
- Corrected a typo 
 