### PR TITLE
Updated service file to solve error

### DIFF
--- a/installing.md
+++ b/installing.md
@@ -71,7 +71,7 @@ After=network.target
 User=<user to run the service>
 Group=<(optional) group with permissions to access augur_view directory>
 WorkingDirectory=<augur_view directory absolute path>
-ExecStart=env/bin/gunicorn -c gunicorn.conf -b 0.0.0.0:8000 wsgi:app
+ExecStart=<augur_view directory absolute path>/env/bin/gunicorn -c gunicorn.conf -b 0.0.0.0:8000 wsgi:app
 
 [Install]
 WantedBy=multi-user.target

--- a/installing.md
+++ b/installing.md
@@ -71,7 +71,7 @@ After=network.target
 User=<user to run the service>
 Group=<(optional) group with permissions to access augur_view directory>
 WorkingDirectory=<augur_view directory absolute path>
-ExecStart=<augur_view directory absolute path>/env/bin/gunicorn -c gunicorn.conf -b 0.0.0.0:8000 wsgi:app
+ExecStart=<virtual environment absolute path>/env/bin/gunicorn -c gunicorn.conf -b 0.0.0.0:8000 wsgi:app
 
 [Install]
 WantedBy=multi-user.target

--- a/installing.md
+++ b/installing.md
@@ -69,7 +69,7 @@ After=network.target
 
 [Service]
 User=<user to run the service>
-Group=<(optional) goup with permissions to access augur_view directory>
+Group=<(optional) group with permissions to access augur_view directory>
 WorkingDirectory=<augur_view directory absolute path>
 ExecStart=env/bin/gunicorn -c gunicorn.conf -b 0.0.0.0:8000 wsgi:app
 

--- a/installing.md
+++ b/installing.md
@@ -57,7 +57,7 @@ You'll need to modify the file to your environment parameters.
 - The `Group` parameter optionally specifies the group to run the process as. It's not required for operation.
 - The `WorkingDirectory` parameter describes where the service working directory is. This parameter should be set to the root directory where the `augur_view` executables are located.
 - The `ExecStart` parameter describes the program to run when the service is started. For `augur_view`, we want Gunicorn to run on startup. In this instance, we need to break up this parameter into multiple parts:
-    - First, we need the absolute or relative (to the `WorkingDirectory`) path to the Gunicorn executable. In this case, because our virtual environment is in the `augur_view` root directory, we are using the relative path to the executable.
+    - First argument will be absolute path or relative path to Gunicorn executable in our virtual environment. For example, if your virtual environment is in the `augur_view` root directory, the relative path will be `<augur_view directory absolute path>/env/bin/gunicorn`
     - Second, using the `-c` option, we specify the Gunicorn config file (which we demonstrate creating below), using its absolute or relative path.
     - Third, using the `-b` option, we specify the address for Gunicorn to bind to. In this case, we are using the local loopback address at port `8000`.
     - Finally, we specify the wsgi driver module we created earlier in `wsgi.py`, using its absolute or relative path.

--- a/installing.md
+++ b/installing.md
@@ -57,7 +57,7 @@ You'll need to modify the file to your environment parameters.
 - The `Group` parameter optionally specifies the group to run the process as. It's not required for operation.
 - The `WorkingDirectory` parameter describes where the service working directory is. This parameter should be set to the root directory where the `augur_view` executables are located.
 - The `ExecStart` parameter describes the program to run when the service is started. For `augur_view`, we want Gunicorn to run on startup. In this instance, we need to break up this parameter into multiple parts:
-    - First argument will be absolute path or relative path to Gunicorn executable in our virtual environment. For example, if your virtual environment is in the `augur_view` root directory, the relative path will be `<augur_view directory absolute path>/env/bin/gunicorn`
+    - First argument will be the absolute path to the Gunicorn executable, which is installed within the virtual environment.
     - Second, using the `-c` option, we specify the Gunicorn config file (which we demonstrate creating below), using its absolute or relative path.
     - Third, using the `-b` option, we specify the address for Gunicorn to bind to. In this case, we are using the local loopback address at port `8000`.
     - Finally, we specify the wsgi driver module we created earlier in `wsgi.py`, using its absolute or relative path.


### PR DESCRIPTION
Current Behaviour: On starting the service file the following error occurs:
`Failed to start augur_view.service: Unit augur_view.service has a bad unit file setting`. and the log shows: 

`Neither a valid executable name nor an absolute path`
`Unit configuration has fatal error, unit will not be started.`

Solution and changes made:

- Updating the service file adding absolute path of directory to ExecStart.
- Corrected a typo